### PR TITLE
Linter adjustments

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -11,6 +11,7 @@
         "plugin:@typescript-eslint/recommended",
         ],
         "rules": {
+            "@typescript-eslint/semi": ["error", "always"],
             "@typescript-eslint/explicit-member-accessibility": "off",
             "@typescript-eslint/explicit-function-return-type": [
                 "error",
@@ -26,7 +27,7 @@
                 "functions": "only-multiline"
             }],
             "indent": ["error", 2],
-            "max-len": ["warn", { "code": 80 }],
+            "max-len": ["warn", { "code": 120 }],
             "no-invalid-this": "error",
             "no-param-reassign": ["error", { "props": false }],
             "object-curly-spacing": ["error", "always"],

--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -1,0 +1,11 @@
+#!/bin/sh
+#
+# An example hook script to verify what is about to be committed.
+# Called by "git commit" with no arguments.  The hook should
+# exit with non-zero status after issuing an appropriate message if
+# it wants to stop the commit.
+#
+# To enable this hook, rename this file to "pre-commit".
+
+# Commits shoudln't have compile or lint errors
+yarn build && yarn lint

--- a/.pug-lintrc.json
+++ b/.pug-lintrc.json
@@ -1,0 +1,4 @@
+{
+  "extends": "clock",
+  "validateAttributeQuoteMarks": "\""
+}

--- a/README.md
+++ b/README.md
@@ -11,5 +11,8 @@
 To start developing, run `yarn dev`. This will start a development server on [localhost:3000](http://localhost:3000) which automatically recompiles and restarts the server when you change any code files in `src/`.
 
 The database will be a empty when you start, you can fill it with some randomly generated data with `yarn run db:seed`.
+
 It is also possible to fill the database with already existing stores. In order to do this, you will need to place the
 exported .csv file containing the stores in the `data` folder and name it `data.csv`. Then, run `yarn run db:import`.
+
+It would be nice if all commits were free of compiler and linter errors. A nice way to automate this check is to enable a pre-commit hook to check this with `ln -s "$PWD/.hooks/pre-commit" .git/hooks/`. If you really have to, you can skip this check with `git commit -n`.

--- a/package.json
+++ b/package.json
@@ -12,7 +12,9 @@
     "dev": "yarn run watch-serve",
     "test": "nyc ava",
     "typeorm": "ts-node ./node_modules/typeorm/cli.js",
-    "lint": "eslint --ext .ts ."
+    "lint:ts": "eslint --ext .ts .",
+    "lint:pug": "pug-lint views/",
+    "lint": "yarn run lint:ts && yarn run lint:pug"
   },
   "devDependencies": {
     "@ava/typescript": "^1.1.1",
@@ -28,6 +30,8 @@
     "faker": "^4.1.0",
     "nodemon": "^2.0.3",
     "nyc": "^15.0.1",
+    "pug-lint": "^2.6.0",
+    "pug-lint-config-clock": "^2.0.0",
     "supertest": "^4.0.2",
     "ts-node": "^8.8.2",
     "typescript": "^3.8.3"

--- a/src/controllers/winkels.ts
+++ b/src/controllers/winkels.ts
@@ -16,7 +16,7 @@ export async function getStores(req: Request, res: Response): Promise<void> {
  * Shows page for store with given id
  */
 export async function getStore(req: Request, res: Response): Promise<void> {
-  const store = await getRepository(Store).findOne(req.params["storeId"])
+  const store = await getRepository(Store).findOne(req.params["storeId"]);
   if (store !== undefined) {
     const tags = await store.tags;
     res.render("store", { store: store, tags: tags });

--- a/src/import.ts
+++ b/src/import.ts
@@ -12,7 +12,7 @@ async function addTags(tagNames: string[]): Promise<Tag[]> {
     tag.name = name;
     await tag.save();
     return tag;
-  }))
+  }));
 }
 
 async function addStores(storeRecords: Record<string, any>[], tags: Tag[]): Promise<Store[]>{
@@ -24,8 +24,8 @@ async function addStores(storeRecords: Record<string, any>[], tags: Tag[]): Prom
     store.postcode = storeRecord["Postcode / Gemeente"];
     store.tags = Promise.resolve(tags.filter(tag => tag.name === storeRecord["Categorie"]));
     await store.save();
-    return store
-  }))
+    return store;
+  }));
 }
 
 async function processData(results: Record<string, any>[]): Promise<void> {
@@ -35,14 +35,14 @@ async function processData(results: Record<string, any>[]): Promise<void> {
   const res = results.slice(0, -1);
 
   const tagNames: string[] = res.filter((val: Record<string, any>) => {
-    return val["Categorie"] !== undefined && val["Categorie"].length > 0
+    return val["Categorie"] !== undefined && val["Categorie"].length > 0;
   }).map((val: Record<string, any>) => val["Categorie"]);
 
   const uniqueTagNames: string[] = Array.from(new Set(tagNames));
   const tags: Tag[] = await addTags(uniqueTagNames);
   await addStores(res, tags);
 
-  console.log("Done")
+  console.log("Done");
 }
 
 async function seedActualStores(): Promise<void> {

--- a/src/models/store.ts
+++ b/src/models/store.ts
@@ -1,5 +1,5 @@
 import { BaseEntity, Entity, Column, PrimaryGeneratedColumn, ManyToMany, JoinTable } from "typeorm";
-import { Tag } from "./tag"
+import { Tag } from "./tag";
 
 @Entity()
 export class Store extends BaseEntity {

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,6 @@ spawn().then(app => {
       app.get("env")
     );
     console.log("  Press CTRL-C to stop\n");
-  })
+  });
 });
 

--- a/views/home.pug
+++ b/views/home.pug
@@ -1,7 +1,7 @@
 h1 KaaBee
 h2 Welkom, wij hebben #{ storeCount } winkels die staat te popelen om je te ontvangen!
 ul
+  li
+    a(href="/winkels") Onze winkels
     li
-        a(href="/winkels") Onze winkels
-    li
-        a(href="/tags") Tags
+      a(href="/tags") Tags

--- a/views/layout.pug
+++ b/views/layout.pug
@@ -1,19 +1,18 @@
 doctype html
-html(lang='nl')
+html(lang="nl")
   head
-    meta(charset='utf-8')
-    meta(http-equiv='X-UA-Compatible', content='IE=edge')
-    meta(name='viewport', content='width=device-width, initial-scale=1.0')
+    meta(charset="utf-8")
+    meta(http-equiv="X-UA-Compatible", content="IE=edge")
+    meta(name="viewport", content="width=device-width, initial-scale=1.0")
     title #{title}
-    //meta(name='description', content='')
-    //meta(name='theme-color' content='#4DA5F4')
-    //link(rel='stylesheet', href='/css/main.css')
+    //meta(name="description", content="")
+    //meta(name="theme-color" content="#4DA5F4")
+    //link(rel="stylesheet", href="/css/main.css")
 
   body
-    include partials/header
+    include partials/header.pug
 
     main
       block content
 
-    include partials/footer
-
+        include partials/footer.pug

--- a/views/partials/footer.pug
+++ b/views/partials/footer.pug
@@ -1,2 +1,2 @@
 footer
-  a(href='mailto:koopbelgisch@gmail.com') © KaaBee
+  a(href="mailto:koopbelgisch@gmail.com") © KaaBee

--- a/views/partials/header.pug
+++ b/views/partials/header.pug
@@ -1,2 +1,2 @@
 nav
-  a(href='/') Home
+  a(href="/") Home

--- a/views/store.pug
+++ b/views/store.pug
@@ -1,13 +1,13 @@
 h1 Dit is de pagina voor de winkel #{ store.name }.
 ul
-    li
-        a(href="/") Home
+  li
+    a(href="/") Home
 ul
-    li Beschrijving: #{ store.description }
+  li Beschrijving: #{ store.description }
     li BTW-nummer: #{ store.vatnumber }
     li Postcode: #{ store.postcode }
     li Tags:
-        ul
-            each val, index in tags
-                li
-                    a(href="/tags/" + val.id) #{val.name}
+      ul
+        each val, index in tags
+          li
+            a(href="/tags/" + val.id) #{val.name}

--- a/views/stores.pug
+++ b/views/stores.pug
@@ -1,8 +1,8 @@
 h1 Dit zijn al onze winkels.
 ul
-    li
-        a(href="/") Home
+  li
+    a(href="/") Home
 ul
-    each val, index in stores
-        li
-            a(href="/winkels/" + val.id) #{val.name}
+  each val, index in stores
+    li
+      a(href="/winkels/" + val.id) #{val.name}

--- a/views/tag.pug
+++ b/views/tag.pug
@@ -1,8 +1,8 @@
 h1 Dit zijn alle winkels voor de tag #{ tag.name }
 ul
-    li
-        a(href="/") Home
+  li
+    a(href="/") Home
 ul
-    each val, index in stores
-        li
-            a(href="/winkels/" + val.id) #{val.name}
+  each val, index in stores
+    li
+      a(href="/winkels/" + val.id) #{val.name}

--- a/views/tags.pug
+++ b/views/tags.pug
@@ -1,8 +1,8 @@
 h1 Dit zijn alle tags.
 ul
-    li
-        a(href="/") Home
+  li
+    a(href="/") Home
 ul
-    each val, index in tags
-        li
-            a(href="/tags/" + val.id) #{val.name}
+  each val, index in tags
+    li
+      a(href="/tags/" + val.id) #{val.name}

--- a/yarn.lock
+++ b/yarn.lock
@@ -492,7 +492,7 @@ acorn@^3.1.0:
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-3.3.0.tgz#45e37fb39e8da3f25baee3ff5369e2bb5f22017a"
   integrity sha1-ReN/s56No/JbruP/U2niu18iAXo=
 
-acorn@^4.0.4, acorn@~4.0.2:
+acorn@^4.0.1, acorn@^4.0.4, acorn@~4.0.2:
   version "4.0.13"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-4.0.13.tgz#105495ae5361d697bd195c825192e1ad7f253787"
   integrity sha1-EFSVrlNh1pe9GVyCUZLhrX8lN4c=
@@ -1174,6 +1174,11 @@ combined-stream@^1.0.6, combined-stream@~1.0.6:
   dependencies:
     delayed-stream "~1.0.0"
 
+commander@^2.9.0:
+  version "2.20.3"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
+  integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
+
 common-path-prefix@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/common-path-prefix/-/common-path-prefix-3.0.0.tgz#7d007a7e07c58c4b4d5f433131a19141b29f11e0"
@@ -1311,6 +1316,11 @@ crypto-random-string@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/crypto-random-string/-/crypto-random-string-2.0.0.tgz#ef2a7a966ec11083388369baa02ebead229b30d5"
   integrity sha512-v1plID3y9r/lPhviJ1wrXpLeyUIGAZ2SHNYTEapm7/8A9nLPoyvVp3RK/EPFqn5kEznyWgYZNsRtYYIWbuG8KA==
+
+css-selector-parser@^1.1.0:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/css-selector-parser/-/css-selector-parser-1.4.1.tgz#03f9cb8a81c3e5ab2c51684557d5aaf6d2569759"
+  integrity sha512-HYPSb7y/Z7BNDCOrakL4raGO2zltZkbeXyAd6Tg9obzix6QhzxCotdBl6VT0Dv4vZfJGVz3WL/xaEI9Ly3ul0g==
 
 csv-parser@^2.3.2:
   version "2.3.2"
@@ -1834,6 +1844,11 @@ find-cache-dir@^3.2.0:
     make-dir "^3.0.2"
     pkg-dir "^4.1.0"
 
+find-line-column@^0.5.2:
+  version "0.5.2"
+  resolved "https://registry.yarnpkg.com/find-line-column/-/find-line-column-0.5.2.tgz#db00238ff868551a182e74a103416d295a98c8ca"
+  integrity sha1-2wAjj/hoVRoYLnShA0FtKVqYyMo=
+
 find-up@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-3.0.0.tgz#49169f1d7993430646da61ecc5ae355c21c97b73"
@@ -2000,7 +2015,7 @@ glob-parent@^5.0.0, glob-parent@^5.1.0, glob-parent@~5.1.0:
   dependencies:
     is-glob "^4.0.1"
 
-glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
+glob@^7.0.3, glob@^7.1.2, glob@^7.1.3, glob@^7.1.4, glob@^7.1.6:
   version "7.1.6"
   resolved "https://registry.yarnpkg.com/glob/-/glob-7.1.6.tgz#141f33b81a7c2492e125594307480c46679278a6"
   integrity sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==
@@ -2832,7 +2847,7 @@ mimic-response@^1.0.0, mimic-response@^1.0.1:
   resolved "https://registry.yarnpkg.com/mimic-response/-/mimic-response-1.0.1.tgz#4923538878eef42063cb8a3e3b0798781487ab1b"
   integrity sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==
 
-minimatch@^3.0.4:
+minimatch@^3.0.3, minimatch@^3.0.4:
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/minimatch/-/minimatch-3.0.4.tgz#5166e286457f03306064be5497e8dbb0c3d32083"
   integrity sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==
@@ -3404,7 +3419,7 @@ pstree.remy@^1.1.7:
   resolved "https://registry.yarnpkg.com/pstree.remy/-/pstree.remy-1.1.7.tgz#c76963a28047ed61542dc361aa26ee55a7fa15f3"
   integrity sha512-xsMgrUwRpuGskEzBFkH8NmTimbZ5PcPup0LA8JJkHIm2IMUbQcpo3yeLNWVrufEYjh8YwtSVh0xz6UeWc5Oh5A==
 
-pug-attrs@^2.0.4:
+pug-attrs@^2.0.3, pug-attrs@^2.0.4:
   version "2.0.4"
   resolved "https://registry.yarnpkg.com/pug-attrs/-/pug-attrs-2.0.4.tgz#b2f44c439e4eb4ad5d4ef25cac20d18ad28cc336"
   integrity sha512-TaZ4Z2TWUPDJcV3wjU3RtUXMrd3kM4Wzjbe3EWnSsZPsJ3LDI0F3yCnf2/W7PPFF+edUFQ0HgDL1IoxSz5K8EQ==
@@ -3427,7 +3442,7 @@ pug-code-gen@^2.0.2:
     void-elements "^2.0.1"
     with "^5.0.0"
 
-pug-error@^1.3.3:
+pug-error@^1.3.2, pug-error@^1.3.3:
   version "1.3.3"
   resolved "https://registry.yarnpkg.com/pug-error/-/pug-error-1.3.3.tgz#f342fb008752d58034c185de03602dd9ffe15fa6"
   integrity sha512-qE3YhESP2mRAWMFJgKdtT5D7ckThRScXRwkfo+Erqga7dyJdY3ZquspprMCj/9sJ2ijm5hXFWQE/A3l4poMWiQ==
@@ -3445,7 +3460,7 @@ pug-filters@^3.1.1:
     resolve "^1.1.6"
     uglify-js "^2.6.1"
 
-pug-lexer@^4.1.0:
+pug-lexer@^4.0.0, pug-lexer@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/pug-lexer/-/pug-lexer-4.1.0.tgz#531cde48c7c0b1fcbbc2b85485c8665e31489cfd"
   integrity sha512-i55yzEBtjm0mlplW4LoANq7k3S8gDdfC6+LThGEvsK4FuobcKfDAwt6V4jKPH9RtiE3a2Akfg5UpafZ1OksaPA==
@@ -3461,6 +3476,30 @@ pug-linker@^3.0.6:
   dependencies:
     pug-error "^1.3.3"
     pug-walk "^1.1.8"
+
+pug-lint-config-clock@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/pug-lint-config-clock/-/pug-lint-config-clock-2.0.0.tgz#77db919cd76c40d9dcdc22e079d202cb6c507f50"
+  integrity sha1-d9uRnNdsQNnc3CLgedICy2xQf1A=
+
+pug-lint@^2.6.0:
+  version "2.6.0"
+  resolved "https://registry.yarnpkg.com/pug-lint/-/pug-lint-2.6.0.tgz#3964f11bbe6d5a5cb1cf5a20206d7b2fa79907d1"
+  integrity sha512-bCENAUT0grCSlUBIfX1USjpZPQWs5QccxVZoCIT4S+IevTn9NqJyzhrcyq/CFVSCOp9Z+pdwPQIkzdCvZ1pGlQ==
+  dependencies:
+    acorn "^4.0.1"
+    commander "^2.9.0"
+    css-selector-parser "^1.1.0"
+    find-line-column "^0.5.2"
+    glob "^7.0.3"
+    minimatch "^3.0.3"
+    path-is-absolute "^1.0.0"
+    pug-attrs "^2.0.3"
+    pug-error "^1.3.2"
+    pug-lexer "^4.0.0"
+    resolve "^1.1.7"
+    strip-json-comments "^2.0.1"
+    void-elements "^2.0.1"
 
 pug-load@^2.0.12:
   version "2.0.12"
@@ -3698,7 +3737,7 @@ resolve-from@^5.0.0:
   resolved "https://registry.yarnpkg.com/resolve-from/-/resolve-from-5.0.0.tgz#c35225843df8f776df21c57557bc087e9dfdfc69"
   integrity sha512-qYg9KP24dD5qka9J47d0aVky0N+b4fTU89LN9iDnjB5waksiC49rvMB0PrUJQGoTmH50XPiqOvAjDfaijGxYZw==
 
-resolve@^1.1.6, resolve@^1.10.0, resolve@^1.3.2:
+resolve@^1.1.6, resolve@^1.1.7, resolve@^1.10.0, resolve@^1.3.2:
   version "1.15.1"
   resolved "https://registry.yarnpkg.com/resolve/-/resolve-1.15.1.tgz#27bdcdeffeaf2d6244b95bb0f9f4b4653451f3e8"
   integrity sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==
@@ -4097,15 +4136,15 @@ strip-bom@^4.0.0:
   resolved "https://registry.yarnpkg.com/strip-bom/-/strip-bom-4.0.0.tgz#9c3505c1db45bcedca3d9cf7a16f5c5aa3901878"
   integrity sha512-3xurFv5tEgii33Zi8Jtp55wEIILR9eh34FAW00PZf+JnSsTmV/ioewSgQl97JHvgjoRGwPShsWm+IdrxB35d0w==
 
+strip-json-comments@^2.0.1, strip-json-comments@~2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
+  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
+
 strip-json-comments@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-3.0.1.tgz#85713975a91fb87bf1b305cca77395e40d2a64a7"
   integrity sha512-VTyMAUfdm047mwKl+u79WIdrZxtFtn+nBxHeb844XBQ9uMNTuTHdx2hc5RiAJYqwTj3wc/xe5HLSdJSkJ+WfZw==
-
-strip-json-comments@~2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
-  integrity sha1-PFMZQukIwml8DsNEhYwobHygpgo=
 
 superagent@^3.8.3:
   version "3.8.3"


### PR DESCRIPTION
- Maximum allowed line length is set to 120 instead of 80
- Semicolons are now required.
- Pug templates are linted, currently with an indentation of two spaces.
- A pre-commit hook is added to check each commit for compiler and linter errors. You still have to enable it yourself by copying or making a symbolic link to `.git/hooks/`.